### PR TITLE
메일 인증 API를 두 단계로 분리 및 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/exception/UserExceptions.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/exception/UserExceptions.kt
@@ -29,6 +29,13 @@ class EmailSendingException : UserException(
     msg = "인증 이메일 전송에 실패했습니다."
 )
 
+// 회원가입 시 메일 인증 과정을 거치지 않은 경우
+class EmailNotVerifiedException : UserException(
+    errorCode = 0,
+    httpErrorCode = HttpStatus.BAD_REQUEST,
+    msg = "인증이 완료되지 않은 이메일입니다."
+)
+
 // 로그인 실패
 class SignInInvalidException : UserException(
     errorCode = 0,

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/EmailVerification.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/EmailVerification.kt
@@ -19,4 +19,8 @@ class EmailVerification(
             )
         }
     }
+
+    override fun toString(): String {
+        return "{id: $id, email: $email, code: $code, expiryTime: $expiryTime}"
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/persistence/EmailVerificationEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/persistence/EmailVerificationEntity.kt
@@ -16,6 +16,8 @@ class EmailVerificationEntity(
     val email: String,
     @Column(name = "code", nullable = false)
     val code: String,
+    @Column(name = "verified", nullable = false)
+    var verified: Boolean = false,
     @Column(name = "expiryTime", nullable = false)
     val expiryTime: LocalDateTime
 )

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/persistence/EmailVerificationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/mail/persistence/EmailVerificationRepository.kt
@@ -5,5 +5,6 @@ import java.time.LocalDateTime
 
 interface EmailVerificationRepository : JpaRepository<EmailVerificationEntity, Long> {
     fun deleteByExpiryTimeBefore(expiryTime: LocalDateTime)
+    fun findByEmail(email: String): EmailVerificationEntity?
     fun findByEmailAndCode(email: String, code: String): EmailVerificationEntity?
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/controller/User.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/controller/User.kt
@@ -24,4 +24,8 @@ class User(
             )
         }
     }
+
+    override fun toString(): String {
+        return "{id: $id, userNumber: $userNumber, nickname: $nickname, email: $email, isSocial: $isSocial}"
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/controller/UserController.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/controller/UserController.kt
@@ -5,7 +5,6 @@ import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.ForgotPassw
 import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.LoginRequest
 import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.RefreshTokenRequest
 import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.RegisterRequest
-import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.ResetPasswordRequest
 import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.UpdateNicknameRequest
 import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.UpdatePasswordRequest
 import com.wafflestudio.toyproject.memoWithTags.user.dto.UserRequest.VerifyEmailRequest
@@ -32,13 +31,20 @@ class UserController(
 ) {
     @Operation(summary = "사용자 회원가입")
     @PostMapping("/auth/register")
-    fun register(@RequestBody request: RegisterRequest): ResponseEntity<Unit> {
+    fun register(@RequestBody request: RegisterRequest): ResponseEntity<LoginResponse> {
         userService.register(request.email, request.password, request.nickname)
-        userService.sendCodeToEmail(request.email)
-        return ResponseEntity.status(HttpStatus.CREATED).build()
+        val (_, accessToken, refreshToken) = userService.login(request.email, request.password)
+        return ResponseEntity.ok(LoginResponse(accessToken, refreshToken))
     }
 
-    @Operation(summary = "회원가입 이메일 인증")
+    @Operation(summary = "메일 인증 요청")
+    @PostMapping("/auth/send-email")
+    fun sendEmail(@RequestBody request: SendEmailRequest): ResponseEntity<Unit> {
+        userService.sendCodeToEmail(request.email)
+        return ResponseEntity.ok().build()
+    }
+
+    @Operation(summary = "메일 인증 확인")
     @PostMapping("/auth/verify-email")
     fun verifyEmail(@RequestBody request: VerifyEmailRequest): ResponseEntity<Unit> {
         userService.verifyEmail(request.email, request.verificationCode)
@@ -52,17 +58,10 @@ class UserController(
         return ResponseEntity.ok(LoginResponse(accessToken, refreshToken))
     }
 
-    @Operation(summary = "비밀번호 찾기 이메일 인증")
-    @PostMapping("/auth/forgot-password")
-    fun forgotPassword(@RequestBody request: ForgotPasswordRequest): ResponseEntity<Unit> {
-        userService.sendCodeToEmail(request.email)
-        return ResponseEntity.ok().build()
-    }
-
     @Operation(summary = "비밀번호 초기화")
     @PostMapping("/auth/reset-password")
     fun resetPassword(@RequestBody request: ResetPasswordRequest): ResponseEntity<Unit> {
-        userService.resetPasswordWithEmailVerification(request.email, request.verificationCode, request.password)
+        userService.resetPasswordWithEmailVerification(request.email, request.password)
         return ResponseEntity.ok().build()
     }
 
@@ -95,7 +94,7 @@ class UserController(
     @DeleteMapping("/auth/withdrawal")
     fun withdrawal(
         @AuthUser user: User,
-        @RequestBody request: ForgotPasswordRequest
+        @RequestBody request: WithdrawalRequest
     ): ResponseEntity<Unit> {
         userService.deleteUser(user, request.email)
         return ResponseEntity.noContent().build()
@@ -111,3 +110,5 @@ class UserController(
 }
 
 typealias WithdrawalRequest = ForgotPasswordRequest
+typealias SendEmailRequest = ForgotPasswordRequest
+typealias ResetPasswordRequest = LoginRequest

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/dto/UserRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/dto/UserRequest.kt
@@ -21,12 +21,6 @@ sealed class UserRequest {
         val email: String
     ) : UserRequest()
 
-    data class ResetPasswordRequest(
-        val email: String,
-        val verificationCode: String,
-        val password: String
-    ) : UserRequest()
-
     data class UpdatePasswordRequest(
         val originalPassword: String,
         val newPassword: String

--- a/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/persistence/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/toyproject/memoWithTags/user/persistence/UserEntity.kt
@@ -33,7 +33,7 @@ class UserEntity(
     var hashedPassword: String,
 
     @Column(name = "verified", nullable = false)
-    var verified: Boolean = false,
+    var verified: Boolean = true,
 
     @Column(name = "role", nullable = false)
     var role: RoleType = RoleType.ROLE_USER,


### PR DESCRIPTION
## 작업 내용

- [x] 주요 변경 사항 요약
 - 메일 인증 API를 수정: (기존) 회원가입 API 먼저 받아 인증 메일을 보내고 메일 인증 API로 인증 완료 -> (수정) 메일 인증 요청 API, 메일 인증 확인 API, 회원가입 API 순으로 요청받아 작동
 - 회원가입 API 로직 수정: (기존) 단순 회원 정보를 DB에 등록 -> (수정) 회원 정보 등록 후 로그인 처리까지 하여 로그인 응답을 반환 + 회원가입 시 인증된 메일인지 확인하는 로직 추가
 - 비밀번호 초기화 로직 수정: 메일 인증 과정을 회원가입 시와 동일한 요청 API -> 인증 API로 처리
 - 메일 인증을 여러 번 하는 문제 수정
 - 기타 자잘한 수정
- [ ] 관련 이슈 번호 (e.g., #123)

## 테스트 결과

- [x] 로컬에서 테스트 완료
- [ ] CI 통과 여부 확인

## 참고 사항

- 추가적인 설명이 필요하다면 작성해주세요.